### PR TITLE
Replace fs functions with fs.rm()

### DIFF
--- a/.changeset/lemon-gifts-shake.md
+++ b/.changeset/lemon-gifts-shake.md
@@ -1,0 +1,5 @@
+---
+'wp-theme-cli': patch
+---
+
+Replace deprecated function `fs.rmdir()`, `fs.unlink()` with `fs.rm()`

--- a/src/modules/cleaner/operations/removeDirectory.ts
+++ b/src/modules/cleaner/operations/removeDirectory.ts
@@ -27,7 +27,7 @@ export const removeDirectory = async (
       return;
     }
     const fullPath = path.resolve(file);
-    await fs.rmdir(fullPath, { recursive: true });
+    await fs.rm(fullPath, { recursive: true });
 
     operationLogger.complete();
     statistics.addFile('removed', file);

--- a/src/modules/cleaner/operations/removeFile.ts
+++ b/src/modules/cleaner/operations/removeFile.ts
@@ -28,7 +28,7 @@ export const removeFile = async (
     }
 
     const fullPath = path.resolve(file);
-    await fs.unlink(fullPath);
+    await fs.rm(fullPath);
 
     operationLogger.complete();
     statistics.addFile('removed', file);


### PR DESCRIPTION
Replace deprecated function `fs.rmdir()` and `fs.unlink()` with `fs.rm()`